### PR TITLE
1ère itération : rappel des éléments à évaluer

### DIFF
--- a/5_design.md
+++ b/5_design.md
@@ -1,1 +1,3 @@
 # Identification des kernel theories dans un stock de connaissances pertinent et permettant de guider le développement scientifique d'un artefact facilitant les interactions homme-données
+
+## 5.3.1 Construction des propositions de design

--- a/7_evaluation.md
+++ b/7_evaluation.md
@@ -1,1 +1,3 @@
 # 7. Quasi-expérimentations visant à évaluer la capacité d'Innodata à faciliter les interactions entre les opérateurs de l'open data et les *data spaces*
+
+## 7.1.1 Rappel des caractéristiques du prototype et de la question de recherche à laquelle les quasi-expérimentations répondent : comment une base de connaissance lève-t-elle les freins et barrières à l'usage de l'open data ?


### PR DESCRIPTION
Rappeler qu'il s'agit dans cette 1ère itération d'évaluer la capacité d'une base de connaissance partagée à lever les freins à l'usage des données ouvertes